### PR TITLE
Leader election implementation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // TODO: use a released version of swift-jobs
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", from: "1.0.0-beta.8"),
+        .package(url: "https://github.com/thoven87/swift-jobs.git", branch: "leader-election"),
         .package(url: "https://github.com/hummingbird-project/postgres-migrations.git", from: "0.1.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.25.0"),
     ],

--- a/Sources/JobsPostgres/PostgresJobsQueue.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue.swift
@@ -567,7 +567,7 @@ public final class PostgresJobQueue: JobQueueDriver, CancellableJobQueue, Resuma
         }
     }
 
-    func electAsLeader() async throws {
+    public func electLeaderShip() async throws {
         let stream = try await client.query("SELECT pg_try_advisory_lock(\(configuration.lockValue));", logger: self.logger)
         let didElect = try await stream.decode(Bool.self, context: .default).first { _ in true } ?? false
 
@@ -611,9 +611,6 @@ extension PostgresJobQueue {
                 if self.queue.isStopped.withLockedValue({ $0 }) {
                     return nil
                 }
-                // The first node to aquire the lock will be the leader
-                try await queue.electAsLeader()
-
                 if let job = try await queue.popFirst() {
                     return job
                 }

--- a/Tests/JobsPostgresTests/JobsTests.swift
+++ b/Tests/JobsPostgresTests/JobsTests.swift
@@ -215,6 +215,8 @@ final class JobsTests: XCTestCase {
             try await jobQueue.push(TestParameters(value: 9))
             try await jobQueue.push(TestParameters(value: 10))
 
+            let isLeader = try await jobQueue.queue.isLeader()
+            XCTAssertTrue(isLeader)
             await fulfillment(of: [expectation], timeout: 5)
         }
     }

--- a/Tests/JobsPostgresTests/JobsTests.swift
+++ b/Tests/JobsPostgresTests/JobsTests.swift
@@ -215,8 +215,6 @@ final class JobsTests: XCTestCase {
             try await jobQueue.push(TestParameters(value: 9))
             try await jobQueue.push(TestParameters(value: 10))
 
-            let isLeader = try await jobQueue.queue.isLeader()
-            XCTAssertTrue(isLeader)
             await fulfillment(of: [expectation], timeout: 5)
         }
     }


### PR DESCRIPTION
* Leader election implementation
* Right now it's only used to prevent multiple workers (CRON) from enqueuing a job more than once