### PR TITLE
Add acquireLock, releaseLock. Fix metadata for multiple queues

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // TODO: use a released version of swift-jobs
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "lock-schedule"),
+        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "main"),
         .package(url: "https://github.com/hummingbird-project/postgres-migrations.git", from: "0.1.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.25.0"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         // TODO: use a released version of swift-jobs
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "main"),
+        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "lock-schedule"),
         .package(url: "https://github.com/hummingbird-project/postgres-migrations.git", from: "0.1.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.25.0"),
     ],

--- a/Sources/JobsPostgres/Migrations/CreateJobMetadataMigration.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobMetadataMigration.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Hummingbird server framework project
+//
+// Copyright (c) 2025 the Hummingbird authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See hummingbird/CONTRIBUTORS.txt for the list of Hummingbird authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import PostgresMigrations
+import PostgresNIO
+
+struct CreateJobMetadataMigration: DatabaseMigration {
+
+    func apply(connection: PostgresNIO.PostgresConnection, logger: Logging.Logger) async throws {
+        try await connection.query(
+            """
+            CREATE TABLE IF NOT EXISTS swift_jobs.metadata(
+                key TEXT NOT NULL,
+                value BYTEA NOT NULL,
+                expires TIMESTAMPTZ NOT NULL DEFAULT '+infinity',
+                queue_name TEXT NOT NULL DEFAULT 'default',
+                CONSTRAINT key_queue_name PRIMARY KEY (key, queue_name)
+            )
+            """,
+            logger: logger
+        )
+    }
+
+    func revert(connection: PostgresNIO.PostgresConnection, logger: Logging.Logger) async throws {
+        try await connection.query(
+            """
+            DROP TABLE swift_jobs.metadata
+            """,
+            logger: logger
+        )
+    }
+
+    var description: String { "__JobMetadataMigration__" }
+    var group: DatabaseMigrationGroup { .jobQueue }
+}

--- a/Sources/JobsPostgres/Migrations/CreateJobMetadataMigration.swift
+++ b/Sources/JobsPostgres/Migrations/CreateJobMetadataMigration.swift
@@ -24,7 +24,7 @@ struct CreateJobMetadataMigration: DatabaseMigration {
             CREATE TABLE IF NOT EXISTS swift_jobs.metadata(
                 key TEXT NOT NULL,
                 value BYTEA NOT NULL,
-                expires TIMESTAMPTZ NOT NULL DEFAULT '+infinity',
+                expires TIMESTAMPTZ NOT NULL DEFAULT 'infinity',
                 queue_name TEXT NOT NULL DEFAULT 'default',
                 CONSTRAINT key_queue_name PRIMARY KEY (key, queue_name)
             )

--- a/Sources/JobsPostgres/Migrations/CreateSwiftJobsMigrations.swift
+++ b/Sources/JobsPostgres/Migrations/CreateSwiftJobsMigrations.swift
@@ -55,25 +55,6 @@ struct CreateSwiftJobsMigrations: DatabaseMigration {
             """,
             logger: logger
         )
-
-        try await connection.query(
-            """
-            CREATE TABLE IF NOT EXISTS swift_jobs.queues_metadata(
-                key TEXT PRIMARY KEY,
-                value BYTEA NOT NULL,
-                queue_name TEXT NOT NULL DEFAULT 'default'
-            )
-            """,
-            logger: logger
-        )
-
-        try await connection.query(
-            """
-            CREATE INDEX IF NOT EXISTS queues_metadata_key_queue_name_idx
-            ON swift_jobs.queues_metadata(key, queue_name)
-            """,
-            logger: logger
-        )
     }
 
     func revert(connection: PostgresNIO.PostgresConnection, logger: Logging.Logger) async throws {

--- a/Sources/JobsPostgres/PostgresJobsQueue.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue.swift
@@ -587,6 +587,8 @@ extension PostgresJobQueue: JobMetadataDriver {
     @inlinable
     public func acquireLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool {
         let expires = Date.now + expiresIn
+        // insert key, value, expiration into table. On conflict with key and queue_name only set value and
+        // expiration if expiration is out of date or value is the same
         let stream = try await self.client.query(
             """
             INSERT INTO swift_jobs.metadata (key, value, expires, queue_name)

--- a/Sources/JobsPostgres/PostgresJobsQueue.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue.swift
@@ -42,7 +42,7 @@ import PostgresNIO
 ///     try await migrations.apply(client: postgresClient, logger: logger, dryRun: applyMigrations)
 /// }
 /// ```
-public final class PostgresJobQueue: JobQueueDriver, JobMetadataDriver, CancellableJobQueue, ResumableJobQueue {
+public final class PostgresJobQueue: JobQueueDriver, CancellableJobQueue, ResumableJobQueue {
 
     public typealias JobID = UUID
 
@@ -158,6 +158,7 @@ public final class PostgresJobQueue: JobQueueDriver, JobMetadataDriver, Cancella
         self.isStopped = .init(false)
         self.migrations = migrations
         await migrations.add(CreateSwiftJobsMigrations(), skipDuplicates: true)
+        await migrations.add(CreateJobMetadataMigration(), skipDuplicates: true)
         self.registerCleanupJob()
     }
 
@@ -289,31 +290,6 @@ public final class PostgresJobQueue: JobQueueDriver, JobMetadataDriver, Cancella
 
     /// shutdown queue once all active jobs have been processed
     public func shutdownGracefully() async {}
-
-    @inlinable
-    public func getMetadata(_ key: String) async throws -> ByteBuffer? {
-        let stream = try await self.client.query(
-            "SELECT value FROM swift_jobs.queues_metadata WHERE key = \(key) AND queue_name = \(configuration.queueName)",
-            logger: self.logger
-        )
-        for try await value in stream.decode(ByteBuffer.self) {
-            return value
-        }
-        return nil
-    }
-
-    @inlinable
-    public func setMetadata(key: String, value: ByteBuffer) async throws {
-        try await self.client.query(
-            """
-            INSERT INTO swift_jobs.queues_metadata (key, value, queue_name)
-            VALUES (\(key), \(value), \(configuration.queueName))
-            ON CONFLICT (key)
-            DO UPDATE SET value = \(value)
-            """,
-            logger: self.logger
-        )
-    }
 
     @usableFromInline
     func popFirst() async throws -> JobQueueResult<JobID>? {
@@ -572,6 +548,79 @@ extension PostgresJobQueue {
 
     public func makeAsyncIterator() -> AsyncIterator {
         .init(queue: self)
+    }
+}
+
+extension PostgresJobQueue: JobMetadataDriver {
+    @inlinable
+    public func getMetadata(_ key: String) async throws -> ByteBuffer? {
+        let stream = try await self.client.query(
+            "SELECT value FROM swift_jobs.metadata WHERE key = \(key) AND queue_name = \(self.configuration.queueName)",
+            logger: self.logger
+        )
+        for try await value in stream.decode(ByteBuffer.self) {
+            return value
+        }
+        return nil
+    }
+
+    @inlinable
+    public func setMetadata(key: String, value: ByteBuffer) async throws {
+        try await self.client.query(
+            """
+            INSERT INTO swift_jobs.metadata (key, value, queue_name)
+            VALUES (\(key), \(value), \(self.configuration.queueName))
+            ON CONFLICT (key, queue_name)
+            DO UPDATE SET value = \(value)
+            """,
+            logger: self.logger
+        )
+    }
+
+    /// Acquire metadata lock
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    ///   - expiresIn: When lock will expire
+    /// - Returns: If lock was acquired
+    @inlinable
+    public func acquireLock(key: String, id: ByteBuffer, expiresIn: TimeInterval) async throws -> Bool {
+        let expires = Date.now + expiresIn
+        let stream = try await self.client.query(
+            """
+            INSERT INTO swift_jobs.metadata (key, value, expires, queue_name)
+            VALUES (\(key), \(id), \(expires), \(self.configuration.queueName))
+            ON CONFLICT (key, queue_name)
+            DO UPDATE
+            SET value = \(id), expires = \(expires)
+            WHERE swift_jobs.metadata.expires <= now()
+            OR swift_jobs.metadata.value = \(id)
+            RETURNING value
+            """,
+            logger: self.logger
+        )
+        for try await value in stream.decode(ByteBuffer.self) {
+            return value == id
+        }
+        return false
+    }
+
+    /// Release metadata lock
+    ///
+    /// - Parameters:
+    ///   - key: Metadata key
+    ///   - id: Lock identifier
+    @inlinable
+    public func releaseLock(key: String, id: ByteBuffer) async throws {
+        _ = try await self.client.query(
+            """
+            DELETE FROM swift_jobs.metadata
+            WHERE key = \(key)
+            AND value = \(id)
+            AND queue_name = \(self.configuration.queueName)
+            """
+        )
     }
 }
 


### PR DESCRIPTION
- Moved metadata setup to separate migration. 
- Renamed metadata table to swift_jobs.metadata