### PR TITLE
Conform PostgresJobQueue to JobServiceDriver

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // MARK: update to a released version before publishing
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "main"),
+        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", from: "1.3.0"),
         .package(url: "https://github.com/hummingbird-project/postgres-migrations.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.30.1"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // MARK: update to a released version before publishing
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "job-service"),
+        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "main"),
         .package(url: "https://github.com/hummingbird-project/postgres-migrations.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.30.1"),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // MARK: update to a released version before publishing
-        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", from: "1.1.0"),
+        .package(url: "https://github.com/hummingbird-project/swift-jobs.git", branch: "job-service"),
         .package(url: "https://github.com/hummingbird-project/postgres-migrations.git", from: "1.0.0"),
         .package(url: "https://github.com/vapor/postgres-nio.git", from: "1.30.1"),
     ],

--- a/Sources/JobsPostgres/PostgresJobsQueue+cleanup.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue+cleanup.swift
@@ -174,6 +174,10 @@ extension PostgresJobQueue: JobServiceDriver {
         }
     }
 
+    /// Schedule queue cleanup
+    /// - Parameters:
+    ///   - schedule: Job schedule to add cleanup scheduled jobs
+    ///   - options: options
     public func scheduleQueueCleanup(_ schedule: inout JobSchedule, options: CleanupOptions) {
         schedule.addJob(self.cleanupProcessingJob, parameters: options.orphaned.parameters, schedule: options.orphaned.schedule)
         if let jobCleanup = options.jobs {

--- a/Sources/JobsPostgres/PostgresJobsQueue+cleanup.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue+cleanup.swift
@@ -41,7 +41,7 @@ public struct PostgresJobCleanupParameters: Sendable & Codable {
 }
 
 /// Parameters for cleanup of jobs stuck in processing
-public struct PostgresProcessingJobCleanupParameters: Sendable, Codable {
+public struct PostgresOrphanedJobCleanupParameters: Sendable, Codable {
     let maxJobsToProcess: Int
 
     ///  Initialize PostgresProcessingJobCleanupParameters
@@ -51,8 +51,10 @@ public struct PostgresProcessingJobCleanupParameters: Sendable, Codable {
         self.maxJobsToProcess = maxJobsToProcess
     }
 }
+@available(*, deprecated, renamed: "PostgresOrphanedJobCleanupParameters")
+public typealias PostgresProcessingJobCleanupParameters = PostgresOrphanedJobCleanupParameters
 
-extension PostgresJobQueue {
+extension PostgresJobQueue: JobServiceDriver {
     /// what to do with failed/processing jobs from last time queue was handled
     public struct JobCleanup: Sendable, Codable {
         enum RawValue: Codable {
@@ -83,7 +85,7 @@ extension PostgresJobQueue {
     /// clean of hung processing jobs job name.
     ///
     /// Use this with the ``/Jobs/JobSchedule`` to schedule a cleanup hung processing jobs
-    public var cleanupProcessingJob: JobName<PostgresProcessingJobCleanupParameters> {
+    public var cleanupProcessingJob: JobName<PostgresOrphanedJobCleanupParameters> {
         .init("_Jobs_PostgresProcessingCleanup_\(self.configuration.queueName)")
     }
 
@@ -113,7 +115,7 @@ extension PostgresJobQueue {
         // This ensures that Jobs scheduled with the legacy
         // `_Jobs_ValkeyProcessingCleanup_` name will still be processed.
 
-        var legacyCleanupProcessingJob: JobName<PostgresProcessingJobCleanupParameters> {
+        var legacyCleanupProcessingJob: JobName<PostgresOrphanedJobCleanupParameters> {
             .init("_Jobs_ValkeyProcessingCleanup_\(self.configuration.queueName)")
         }
 
@@ -122,6 +124,61 @@ extension PostgresJobQueue {
                 try await self.cleanupProcessingJobs(maxJobsToProcess: parameters.maxJobsToProcess)
             }
         )
+    }
+
+    /// Queue cleanup schedule options
+    public struct CleanupOptions: JobQueueCleanupOptionsProtocol {
+        /// Cleanup options for jobs in various types of state (completed, failed, cancelled, paused)
+        var jobs: JobCleanup?
+        /// Orphaned job cleanup options
+        ///
+        /// An orphaned job is a job who that finished because the server it was running on crashed
+        var orphaned: OrphanedJobsCleanup
+
+        public init(
+            jobs: JobCleanup? = .init(),
+            orphaned: OrphanedJobsCleanup = .init()
+        ) {
+            self.jobs = jobs
+            self.orphaned = orphaned
+        }
+
+        public static var `default`: Self { .init() }
+
+        /// Cleanup options for jobs in various types of state (completed, failed, cancelled, paused)
+        public struct JobCleanup: Sendable {
+            var parameters: PostgresJobCleanupParameters
+            var schedule: Schedule
+
+            public init(
+                parameters: PostgresJobCleanupParameters = .init(),
+                schedule: Schedule = .daily()
+            ) {
+                self.parameters = parameters
+                self.schedule = schedule
+            }
+        }
+
+        /// Orphaned job cleanup options
+        public struct OrphanedJobsCleanup: Sendable {
+            var parameters: PostgresOrphanedJobCleanupParameters
+            var schedule: Schedule
+
+            public init(
+                parameters: PostgresOrphanedJobCleanupParameters = .init(maxJobsToProcess: .max),
+                schedule: Schedule = .onMinutes([0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55])
+            ) {
+                self.parameters = parameters
+                self.schedule = schedule
+            }
+        }
+    }
+
+    public func scheduleQueueCleanup(_ schedule: inout JobSchedule, options: CleanupOptions) {
+        schedule.addJob(self.cleanupProcessingJob, parameters: options.orphaned.parameters, schedule: options.orphaned.schedule)
+        if let jobCleanup = options.jobs {
+            schedule.addJob(self.cleanupJob, parameters: jobCleanup.parameters, schedule: jobCleanup.schedule)
+        }
     }
 
     ///  Cleanup job queues

--- a/Sources/JobsPostgres/PostgresJobsQueue+cleanup.swift
+++ b/Sources/JobsPostgres/PostgresJobsQueue+cleanup.swift
@@ -132,7 +132,7 @@ extension PostgresJobQueue: JobServiceDriver {
         var jobs: JobCleanup?
         /// Orphaned job cleanup options
         ///
-        /// An orphaned job is a job who that finished because the server it was running on crashed
+        /// An orphaned job is a job that has not finished because the server it was running on crashed.
         var orphaned: OrphanedJobsCleanup
 
         public init(

--- a/Tests/JobsPostgresTests/JobsTests.swift
+++ b/Tests/JobsPostgresTests/JobsTests.swift
@@ -31,10 +31,10 @@ func getPostgresConfiguration() -> PostgresClient.Configuration {
 
 @Suite("Postgres Jobs Queue", .postgresMigrations(configuration: getPostgresConfiguration()))
 struct JobsTests {
-    func createJobQueue(
+    func createPostgresJobDriver(
         configuration: PostgresJobQueue.Configuration = .init(),
         function: String = #function
-    ) async throws -> JobQueue<PostgresJobQueue> {
+    ) async -> PostgresJobQueue {
         let logger = {
             var logger = Logger(label: function)
             logger.logLevel = .debug
@@ -49,15 +49,40 @@ struct JobsTests {
             backgroundLogger: logger
         )
         let postgresMigrations = DatabaseMigrations()
-        return await JobQueue(
-            .postgres(
-                client: postgresClient,
-                migrations: postgresMigrations,
-                configuration: configuration,
-                logger: logger
-            ),
-            logger: logger,
+        return await .postgres(
+            client: postgresClient,
+            migrations: postgresMigrations,
+            configuration: configuration,
+            logger: logger
+        )
+    }
+
+    func createJobQueue(
+        configuration: PostgresJobQueue.Configuration = .init(),
+        function: String = #function
+    ) async throws -> JobQueue<PostgresJobQueue> {
+        let postgresDriver = await createPostgresJobDriver(configuration: configuration, function: function)
+        return JobQueue(
+            postgresDriver,
+            logger: postgresDriver.logger,
             options: .init(defaultRetryStrategy: .exponentialJitter(maxBackoff: .milliseconds(10)))
+        )
+    }
+
+    func createJobService(
+        serviceOptions: JobService<PostgresJobQueue>.Options = .init(
+            queue: .init(defaultRetryStrategy: .exponentialJitter(maxBackoff: .milliseconds(10)))
+        ),
+        configuration: PostgresJobQueue.Configuration = .init(),
+        function: String = #function
+    ) async throws -> (JobService<PostgresJobQueue>, PostgresJobQueue) {
+        let postgresDriver = await createPostgresJobDriver(configuration: configuration, function: function)
+        return (
+            JobService(
+                postgresDriver,
+                logger: postgresDriver.logger,
+                options: serviceOptions
+            ), postgresDriver
         )
     }
 
@@ -1145,7 +1170,7 @@ struct JobsTests {
         // Create job using the LEGACY valkey name
         // The job handler is registered automatically by registerCleanupJobs() during queue init
         // This is what we're testing - that this automatic registration works
-        let legacyCleanupJobName = JobName<PostgresProcessingJobCleanupParameters>(
+        let legacyCleanupJobName = JobName<PostgresOrphanedJobCleanupParameters>(
             "_Jobs_ValkeyProcessingCleanup_\(jobQueue.queue.configuration.queueName)"
         )
 
@@ -1185,6 +1210,84 @@ struct JobsTests {
             #expect(pendingJobs.count == 0)  // Job was picked up
             #expect(failedJobs.count == 0)  // Job processed successfully (did not fail)
 
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test
+    func testJobService() async throws {
+        struct TestParameters: JobParameters {
+            static let jobName = "runJob"
+            let value: Int
+        }
+        var logger = Logger(label: "runJob")
+        logger.logLevel = .trace
+        let (jobService, postgresDriver) = try await self.createJobService()
+        return try await withThrowingTaskGroup(of: Void.self) { group in
+            let serviceGroup = ServiceGroup(
+                configuration: .init(
+                    services: [postgresDriver.client, jobService],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: logger
+                )
+            )
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await postgresDriver.migrations.apply(client: postgresDriver.client, groups: [.jobQueue], logger: logger, dryRun: false)
+            let (stream, cont) = AsyncStream.makeStream(of: Int.self)
+            jobService.registerJob(parameters: TestParameters.self) { parameter, _ in
+                cont.yield(parameter.value)
+            }
+            try await jobService.push(TestParameters(value: 4))
+            let value = await stream.first { _ in true }
+            #expect(value == 4)
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    @Test
+    func testJobServiceCleanup() async throws {
+        struct CatchJobMiddleware: JobMiddleware {
+            let cont: AsyncStream<String>.Continuation
+            func onPushJob<Parameters>(name: String, parameters: Parameters, context: JobPushQueueContext) async {
+                cont.yield(name)
+            }
+        }
+        // create schedule that ensures a job will be run in the next second
+        let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: Date.now + 1)
+        let postgresDriver = await createPostgresJobDriver(configuration: .init())
+        let (stream, cont) = AsyncStream.makeStream(of: String.self)
+        let jobService = JobService(
+            postgresDriver,
+            logger: postgresDriver.logger,
+            options: .init(
+                cleanup: .init(
+                    jobs: .init(schedule: .everyMinute(second: dateComponents.second!)),
+                    orphaned: .init(schedule: .everyMinute(second: dateComponents.second!))
+                )
+            )
+        ) {
+            CatchJobMiddleware(cont: cont)
+        }
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            let serviceGroup = ServiceGroup(
+                configuration: .init(
+                    services: [postgresDriver.client, jobService],
+                    gracefulShutdownSignals: [.sigterm, .sigint],
+                    logger: jobService.logger
+                )
+            )
+            group.addTask {
+                try await serviceGroup.run()
+            }
+            try await postgresDriver.migrations.apply(client: postgresDriver.client, groups: [.jobQueue], logger: jobService.logger, dryRun: false)
+            var iterator = stream.makeAsyncIterator()
+            let value = try await #require(iterator.next())
+            let value2 = try await #require(iterator.next())
+            let values: Set<String> = [value, value2]
+            #expect(values == Set([postgresDriver.cleanupJob.name, postgresDriver.cleanupProcessingJob.name]))
             await serviceGroup.triggerGracefulShutdown()
         }
     }

--- a/Tests/JobsPostgresTests/JobsTests.swift
+++ b/Tests/JobsPostgresTests/JobsTests.swift
@@ -1247,6 +1247,7 @@ struct JobsTests {
         }
     }
 
+    /// Check scheduled cleanup jobs run
     @Test
     func testJobServiceCleanup() async throws {
         struct CatchJobMiddleware: JobMiddleware {
@@ -1255,7 +1256,6 @@ struct JobsTests {
                 cont.yield(name)
             }
         }
-        // create schedule that ensures a job will be run in the next second
         let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: Date.now + 1)
         let postgresDriver = await createPostgresJobDriver(configuration: .init())
         let (stream, cont) = AsyncStream.makeStream(of: String.self)

--- a/Tests/JobsPostgresTests/JobsTests.swift
+++ b/Tests/JobsPostgresTests/JobsTests.swift
@@ -69,23 +69,6 @@ struct JobsTests {
         )
     }
 
-    func createJobService(
-        serviceOptions: JobService<PostgresJobQueue>.Options = .init(
-            queue: .init(defaultRetryStrategy: .exponentialJitter(maxBackoff: .milliseconds(10)))
-        ),
-        configuration: PostgresJobQueue.Configuration = .init(),
-        function: String = #function
-    ) async throws -> (JobService<PostgresJobQueue>, PostgresJobQueue) {
-        let postgresDriver = await createPostgresJobDriver(configuration: configuration, function: function)
-        return (
-            JobService(
-                postgresDriver,
-                logger: postgresDriver.logger,
-                options: serviceOptions
-            ), postgresDriver
-        )
-    }
-
     /// Helper function for test a server
     ///
     /// Creates test client, runs test function abd ensures everything is
@@ -1222,7 +1205,11 @@ struct JobsTests {
         }
         var logger = Logger(label: "runJob")
         logger.logLevel = .trace
-        let (jobService, postgresDriver) = try await self.createJobService()
+        let postgresDriver = await createPostgresJobDriver(configuration: .init())
+        let jobService = JobService(
+            postgresDriver,
+            logger: postgresDriver.logger
+        )
         return try await withThrowingTaskGroup(of: Void.self) { group in
             let serviceGroup = ServiceGroup(
                 configuration: .init(
@@ -1257,8 +1244,8 @@ struct JobsTests {
             }
         }
         let dateComponents = Calendar.current.dateComponents([.hour, .minute, .second], from: Date.now + 1)
-        let postgresDriver = await createPostgresJobDriver(configuration: .init())
         let (stream, cont) = AsyncStream.makeStream(of: String.self)
+        let postgresDriver = await createPostgresJobDriver(configuration: .init())
         let jobService = JobService(
             postgresDriver,
             logger: postgresDriver.logger,

--- a/Tests/JobsPostgresTests/JobsTests.swift
+++ b/Tests/JobsPostgresTests/JobsTests.swift
@@ -1271,8 +1271,12 @@ struct JobsTests {
             }
             try await postgresDriver.migrations.apply(client: postgresDriver.client, groups: [.jobQueue], logger: jobService.logger, dryRun: false)
             var iterator = stream.makeAsyncIterator()
-            let value = try await #require(iterator.next())
-            let value2 = try await #require(iterator.next())
+            let value = await iterator.next()
+            let value2 = await iterator.next()
+            guard let value, let value2 else {
+                Issue.record()
+                return
+            }
             let values: Set<String> = [value, value2]
             #expect(values == Set([postgresDriver.cleanupJob.name, postgresDriver.cleanupProcessingJob.name]))
             await serviceGroup.triggerGracefulShutdown()


### PR DESCRIPTION
```swift
let postgresClient = PostgresClient(configuration: .init(host: "127.0.0.1", port: 5432, ...)
let jobService = JobService(
    .postgres(
        postgresClient, 
        migrations: postgresMigrations,
        configuration: .init(retentionPolicy: .init(completedJobs: .retain)), 
        logger: logger
    ),
    logger: logger,
    options: .init(
        processor: .init(numWorkers: 32),
        cleanup: .init(
            jobs: .init(schedule: .hourly())
        )
    )
)
```